### PR TITLE
Gitlab integration: comments are duplicated because of default 20-item pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+
+* [#58](https://github.com/mmozuras/pronto/pull/58): GitlabFormatter uses a high +per_page+ value to avoid pagination (and thus duplicate comments)
 
 ## 0.4.0
 

--- a/lib/pronto/gitlab.rb
+++ b/lib/pronto/gitlab.rb
@@ -7,7 +7,7 @@ module Pronto
 
     def commit_comments(sha)
       @comment_cache["#{sha}"] ||= begin
-        client.commit_comments(slug, sha).map do |comment|
+        client.commit_comments(slug, sha, per_page: 500).map do |comment|
           Comment.new(sha, comment.note, comment.path, comment.line)
         end
       end

--- a/spec/pronto/gitlab_spec.rb
+++ b/spec/pronto/gitlab_spec.rb
@@ -17,7 +17,7 @@ module Pronto
 
           ::Gitlab::Client.any_instance
                           .should_receive(:commit_comments)
-                          .with('mmozuras%2Fpronto', sha)
+                          .with('mmozuras%2Fpronto', sha, per_page: 500)
                           .once
                           .and_return([])
 


### PR DESCRIPTION
I fixed a small issue which leads to duplicate comments on when using the GitlabFormatter: When you have more than 20 comments on a commit, pagination kicks in and not all comments are seen, thus duplicate checking breaks.

I just set per_page to 500 to quickly work around that issue.