### PR TITLE
Fix potential issue with commenting on "out of date" lines

### DIFF
--- a/lib/pronto/git/patches.rb
+++ b/lib/pronto/git/patches.rb
@@ -17,7 +17,7 @@ module Pronto
 
       def find_line(path, line)
         patch = find { |p| p.new_file_full_path == path }
-        lines = patch ? patch.lines : []
+        lines = patch ? patch.added_lines : []
         lines.find { |l| l.new_lineno == line }
       end
     end


### PR DESCRIPTION
Potential fix for https://github.com/mmozuras/pronto/issues/39

We were seeing this issue come up a lot when running pronto on our pull requests. It turns out that when you're looking through the commits for the offending line, you find the first commit where the line exists, regardless of whether or not it's added, deleted, or it's just a context line. As a result you could potentially commit an offending line (that violates rubocop in our case), and then commit a change to a nearby line. When scanning the patches, it would pick the most recent patch, even though that line was actually committed earlier.

What do you think of this? Does it make sense to only find lines that are additions?