### PR TITLE
Possible fix for issue with Github PR formatter commenting on wrong lines

### DIFF
--- a/lib/pronto/formatter/github_pull_request_formatter.rb
+++ b/lib/pronto/formatter/github_pull_request_formatter.rb
@@ -14,7 +14,7 @@ module Pronto
           line = nil
           sha = commits.find do |commit|
             patches = repo.show_commit(commit)
-            line = patches.find_line(message.full_path, message.line.new_lineno)
+            line = patches.find_added_line_with_content(message.full_path, message.line.content)
             line
           end
 

--- a/lib/pronto/git/patches.rb
+++ b/lib/pronto/git/patches.rb
@@ -17,7 +17,7 @@ module Pronto
 
       def find_line(path, line)
         patch = find { |p| p.new_file_full_path == path }
-        lines = patch ? patch.lines : []
+        lines = patch ? patch.added_lines : []
         lines.find { |l| l.new_lineno == line }
       end
     end

--- a/lib/pronto/git/patches.rb
+++ b/lib/pronto/git/patches.rb
@@ -15,10 +15,22 @@ module Pronto
         @patches.each(&block)
       end
 
-      def find_line(path, line)
-        patch = find { |p| p.new_file_full_path == path }
+      def find_line(path, line_number)
+        patch = find_patch_by_path(path)
+        lines = patch ? patch.lines : []
+        lines.find { |l| l.new_lineno == line_number }
+      end
+
+      def find_added_line_with_content(path, content)
+        patch = find_patch_by_path(path)
         lines = patch ? patch.added_lines : []
-        lines.find { |l| l.new_lineno == line }
+        lines.find { |l| l.content == content }
+      end
+
+      private
+
+      def find_patch_by_path(path)
+        find { |p| p.new_file_full_path == path }
       end
     end
   end


### PR DESCRIPTION
Alright, this is to follow up to my previous pr: https://github.com/mmozuras/pronto/pull/72 and is an attempt to fix #39.

The issue is still the same: pronto has issues where you make commits/changes around the same sections of code, as it will actually pick up a line from it's last context, and not when it was added. This then calculates an incorrect position, and comments on a wrong line.

I'll admit this isn't be ideal behavior, as it will now comment on an outdated diff, but to me it is better than commenting on the wrong line.

What do you think?