### PR TITLE
Treat rake files as ruby files

### DIFF
--- a/lib/pronto/runner.rb
+++ b/lib/pronto/runner.rb
@@ -7,10 +7,18 @@ module Pronto
     end
 
     def ruby_file?(path)
-      File.extname(path) == '.rb' || ruby_executable?(path)
+      rb_file?(path) || rake_file?(path) || ruby_executable?(path)
     end
 
     private
+
+    def rb_file?(path)
+      File.extname(path) == '.rb'
+    end
+
+    def rake_file?(path)
+      File.extname(path) == '.rake'
+    end
 
     def ruby_executable?(path)
       line = File.open(path) { |file| file.readline }

--- a/spec/pronto/runner_spec.rb
+++ b/spec/pronto/runner_spec.rb
@@ -17,6 +17,11 @@ module Pronto
         it { should be_truthy }
       end
 
+      context 'ending with .rake' do
+        let(:path) { 'test.rake' }
+        it { should be_truthy }
+      end
+
       context 'executable' do
         let(:path) { 'test' }
         before { File.stub(:open).with(path).and_return(shebang) }


### PR DESCRIPTION
Pronto ignores rake files even if I add this to `.rubocop.yml`:
```
AllCops:
  Include:
    - '**/*.rake'
```

Not sure if it's a proper fix though..

@mmozuras 
