### PR TITLE
Require rugged 0.23.1

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables << 'pronto'
 
-  s.add_runtime_dependency 'rugged', '~> 0.22.0'
+  s.add_runtime_dependency 'rugged', '~> 0.23.0'
   s.add_runtime_dependency 'thor', '~> 0.19.0'
   s.add_runtime_dependency 'octokit', '~> 3.8.0'
   s.add_runtime_dependency 'gitlab', '~> 3.4.0'

--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables << 'pronto'
 
-  s.add_runtime_dependency 'rugged', '~> 0.23.0'
+  s.add_runtime_dependency 'rugged', '~> 0.23.1'
   s.add_runtime_dependency 'thor', '~> 0.19.0'
   s.add_runtime_dependency 'octokit', '~> 3.8.0'
   s.add_runtime_dependency 'gitlab', '~> 3.4.0'


### PR DESCRIPTION
As a fix for https://github.com/libgit2/rugged/issues/475

It also requires this line for rugged in the Gemfile:
```ruby
  gem 'rugged', github: 'libgit2/rugged', ref: '233da19', submodules: true
```