### PR TITLE
Add env var for github slug

### DIFF
--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -35,7 +35,7 @@ module Pronto
     private
 
     def slug
-      @slug ||= begin
+      @slug = ENV['GITHUB_SLUG'] || begin
         @repo.remote_urls.map do |url|
           match = /.*github.com(:|\/)(?<slug>.*).git/.match(url)
           match[:slug] if match

--- a/lib/pronto/gitlab.rb
+++ b/lib/pronto/gitlab.rb
@@ -22,7 +22,7 @@ module Pronto
     private
 
     def slug
-      @slug ||= begin
+      @slug = ENV['GITLAB_SLUG'] || begin
         host = URI.split(endpoint)[2, 2].compact.join(':')
         slug = @repo.remote_urls.map do |url|
           match = /.*#{host}(:|\/)(?<slug>.*).git/.match(url)


### PR DESCRIPTION
Pronto fetches the first url from all available remote urls.
If it is a fork it will be the upstream url

To support forks you should be able to configure this part of the url, too!