### PR TITLE
handle github remote urls without .git suffix

### DIFF
--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -37,7 +37,7 @@ module Pronto
     def slug
       @slug ||= begin
         @repo.remote_urls.map do |url|
-          match = /.*github.com(:|\/)(?<slug>.*).git/.match(url)
+          match = /.*github.com(:|\/)(?<slug>.*?)(?:\.git)?\z/.match(url)
           match[:slug] if match
         end.compact.first
       end

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -8,6 +8,23 @@ module Pronto
     let(:sha) { '61e4bef' }
     let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1) }
 
+    describe '#slug' do
+      let(:repo) { double(remote_urls: ['git@github.com:mmozuras/pronto']) }
+      subject { github.commit_comments(sha) }
+
+      context 'git remote without .git suffix' do
+        specify do
+          Octokit::Client.any_instance
+            .should_receive(:commit_comments)
+            .with('mmozuras/pronto', sha)
+            .once
+            .and_return([comment])
+
+          subject
+        end
+      end
+    end
+
     describe '#commit_comments' do
       subject { github.commit_comments(sha) }
 


### PR DESCRIPTION
```Github#slug``` doesn't correctly parse remote urls if they don't end in ```.git``` even though cloning from github (at least, haven't tested any other servers) works happily with the same urls. if this is a universal thing i'm happy to make the same change for gitlab as well. 