### PR TITLE
Ignore failed pull request comments

### DIFF
--- a/lib/pronto/formatter/github_pull_request_formatter.rb
+++ b/lib/pronto/formatter/github_pull_request_formatter.rb
@@ -24,6 +24,13 @@ module Pronto
         comments = client.pull_comments(sha)
         existing = comments.any? { |c| comment == c }
         client.create_pull_comment(comment) unless existing
+      rescue Octokit::UnprocessableEntity => e
+        # The diff output of the local git version and Github is not always
+        # consistent, especially in areas where file renames happened, Github
+        # tends to recognize these better, leading to messages we can't post
+        # because their diff position is non-existent on Github.
+        # Ignore such occasions and continue posting other messages.
+        STDERR.puts "Failed to post: #{comment.inspect} with #{e.message}"
       end
     end
   end


### PR DESCRIPTION
The diff output of the local git version and Github is not always consistent
especially in areas where file renames happened,  Github tends to recognize
these better, leading to messages we can't post because their diff position is
non-existent on Github.