### PR TITLE
Auto paginate responses from the Github API

### DIFF
--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -44,7 +44,7 @@ module Pronto
     end
 
     def client
-      @client ||= Octokit::Client.new(access_token: access_token)
+      @client ||= Octokit::Client.new(access_token: access_token, auto_paginate: true)
     end
 
     def pull_requests


### PR DESCRIPTION
By default Octokit only fetches the first 30 comments of a pull request,
on large pull requests that makes the duplicate comment detection fail,
leading to duplicates.