### PR TITLE
Fix help descriptions for CLI options

### DIFF
--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -16,30 +16,30 @@ module Pronto
 
     method_option :'exit-code',
                   type: :boolean,
-                  banner: 'Exits with non-zero code if there were any warnings/errors.'
+                  desc: 'Exits with non-zero code if there were any warnings/errors.'
 
     method_option :commit,
                   type: :string,
                   default: 'master',
                   aliases: '-c',
-                  banner: 'Commit for the diff'
+                  desc: 'Commit for the diff'
 
     method_option :index,
                   type: :boolean,
                   aliases: '-i',
-                  banner: 'Analyze changes in git index (staging area)'
+                  desc: 'Analyze changes in git index (staging area)'
 
     method_option :runner,
                   type: :array,
                   default: [],
                   aliases: '-r',
-                  banner: 'Run only the passed runners'
+                  desc: 'Run only the passed runners'
 
     method_option :formatter,
                   type: :string,
                   default: 'text',
                   aliases: '-f',
-                  banner: "Pick output formatter. Available: #{::Pronto::Formatter.names.join(', ')}"
+                  desc: "Pick output formatter. Available: #{::Pronto::Formatter.names.join(', ')}"
 
     def run(path = nil)
       gem_names = options[:runner].any? ? options[:runner] : ::Pronto.gem_names


### PR DESCRIPTION
Currently help looks like this:
```
$ pronto help run
Usage:
  pronto run

Options:
      [--exit-code=Exits with non-zero code if there were any warnings/errors.], [--no-exit-code]              
  -c, [--commit=Commit for the diff]                                                                           
                                                                                                               # Default: master
  -i, [--index=Analyze changes in git index (staging area)], [--no-index]                                      
  -r, [--runner=Run only the passed runners]                                                                   
  -f, [--formatter=Pick output formatter. Available: github, github_pr, gitlab, json, checkstyle, text, null]  
                                                                                                               # Default: text

Run Pronto
```

After this change:
```
$ pronto help run
Usage:
  pronto run

Options:
      [--exit-code], [--no-exit-code]  # Exits with non-zero code if there were any warnings/errors.
  -c, [--commit=COMMIT]                # Commit for the diff
                                       # Default: master
  -i, [--index], [--no-index]          # Analyze changes in git index (staging area)
  -r, [--runner=one two three]         # Run only the passed runners
  -f, [--formatter=FORMATTER]          # Pick output formatter. Available: github, github_pr, gitlab, json, checkstyle, text, null
                                       # Default: text

Run Pronto
```

Much better :smile: 

@mmozuras 