### PR TITLE
Improve github formatter error output

### DIFF
--- a/lib/pronto/formatter/github_pull_request_formatter.rb
+++ b/lib/pronto/formatter/github_pull_request_formatter.rb
@@ -29,7 +29,7 @@ module Pronto
         # tends to recognize these better, leading to messages we can't post
         # because their diff position is non-existent on Github.
         # Ignore such occasions and continue posting other messages.
-        STDERR.puts "Failed to post: #{comment.inspect} with #{e.message}"
+        STDERR.puts "Failed to post: #{comment} with #{e.message}"
       end
     end
   end

--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -85,6 +85,10 @@ module Pronto
           path == other.path &&
           body == other.body
       end
+
+      def to_s
+        "[#{sha}] #{path}:#{position} - #{body}"
+      end
     end
   end
 end


### PR DESCRIPTION
`.inspect` wasn't a nice thing to see. Also added a test for it.