### PR TITLE
Ignore symlink directory

### DIFF
--- a/lib/pronto/runner.rb
+++ b/lib/pronto/runner.rb
@@ -21,6 +21,7 @@ module Pronto
     end
 
     def ruby_executable?(path)
+      return false if File.directory?(path)
       line = File.open(path, &:readline)
       line =~ /#!.*ruby/
     rescue ArgumentError, EOFError

--- a/spec/pronto/runner_spec.rb
+++ b/spec/pronto/runner_spec.rb
@@ -34,6 +34,12 @@ module Pronto
           it { should be_falsy }
         end
       end
+
+      context 'directory' do
+        let(:path) { 'directory' }
+        before { File.stub(:directory?).with(path).and_return(true) }
+        it { should be_falsy }
+      end
     end
   end
 end


### PR DESCRIPTION
If repository has symlink directory, [File#readline](https://github.com/mmozuras/pronto/blob/740e0c70ce150397b34bd7aca7f4370cea622745/lib/pronto/runner.rb#L24) rise error.


```
$ mkdir dir
$ touch dir/.gitkeep
$ ln -s dir sym_dir
$ git add .
$ git status
On branch master

Initial commit

Changes to be committed:
  (use "git rm --cached <file>..." to unstage)

	new file:   dir/.gitkeep
	new file:   sym_dir
```


```
+ bundle exec pronto run -f github_pr -c origin/master
/tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runner.rb:24:in `readline': Is a directory @ io_fillbuf - fd:13 /tmp/project/repos/spec/sym_dir (Errno::EISDIR)
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runner.rb:24:in `open'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runner.rb:24:in `ruby_executable?'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runner.rb:10:in `ruby_file?'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-brakeman-0.5.0/lib/pronto/brakeman.rb:10:in `block in run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-brakeman-0.5.0/lib/pronto/brakeman.rb:10:in `select'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-brakeman-0.5.0/lib/pronto/brakeman.rb:10:in `run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runners.rb:12:in `block in run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runners.rb:12:in `map'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/runners.rb:12:in `run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto.rb:39:in `run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/lib/pronto/cli.rb:52:in `run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /tmp/bundler/repos/ruby/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /tmp/bundler/repos/ruby/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /tmp/bundler/repos/ruby/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /tmp/bundler/repos/ruby/2.3.0/gems/pronto-0.5.3/bin/pronto:6:in `<top (required)>'
	from /tmp/bundler/repos/ruby/2.3.0/bin/pronto:23:in `load'
	from /tmp/bundler/repos/ruby/2.3.0/bin/pronto:23:in `<main>'
```

