### PR TITLE
Add pronto-swiftlint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Currently available:
 * [pronto-rubocop](https://github.com/mmozuras/pronto-rubocop)
 * [pronto-scss](https://github.com/mmozuras/pronto-scss)
 * [pronto-spell](https://github.com/mmozuras/pronto-spell)
+* [pronto-swiftlint](https://github.com/ajanauskas/pronto-swiftlint)
 * [pronto-tailor](https://github.com/ajanauskas/pronto-tailor)
 
 ## Articles


### PR DESCRIPTION
@mmozuras this is second pronto runner for `Swift` language lint tool

Right now both `tailor` and `SwiftLint` seem pretty young projects. `SwiftLint` is more active, however both of them lack features compared to other languages like ruby (`rubocop`)

Will try to support both of the runners, maybe in the future it will be more clear which tool will be used more by `Swift` community