### PR TITLE
Add max_warnings configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ gitlab:
   slug: mmozuras/pronto,
   api_private_token: 46751,
   api_endpoint: https://api.vinted.com/gitlab
+max_warnings: 150
 ```
 
 All properties that can be specified via `.pronto.yml`, can also be specified

--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -21,6 +21,10 @@ module Pronto
       URI.parse(github_web_endpoint).host
     end
 
+    def max_warnings
+      @config_hash['max_warnings']
+    end
+
     private
 
     def exclude

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -17,7 +17,8 @@ module Pronto
         'api_endpoint' => nil
       },
       'runners' => [],
-      'formatters' => []
+      'formatters' => [],
+      'max_warnings' => nil
     }
 
     def initialize(path = '.pronto.yml')

--- a/lib/pronto/runners.rb
+++ b/lib/pronto/runners.rb
@@ -9,8 +9,13 @@ module Pronto
       patches = reject_excluded(patches)
       return [] unless patches.any?
 
-      @runners.map { |runner| runner.new.run(patches, patches.commit) }
-        .flatten.compact
+      result = []
+      @runners.each do |runner|
+        next if @config.max_warnings && result.count >= @config.max_warnings
+        result += runner.new.run(patches, patches.commit).flatten.compact
+      end
+      result = result.take(@config.max_warnings) if @config.max_warnings
+      result
     end
 
     private

--- a/spec/pronto/runners_spec.rb
+++ b/spec/pronto/runners_spec.rb
@@ -25,6 +25,11 @@ module Pronto
           let(:patches) { [double(new_file_full_path: 1)] }
           it { should be_empty }
         end
+
+        context 'max warnings' do
+          let(:config) { double(max_warnings: 1, excluded_files: []) }
+          it { should == [1] }
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds the `max_warnings` configuration to limit the number of warnings.
                                                                                                                                               
When I use pronto with GitHub integration, sometimes pull request pages are filled up comments created by pronto.  Some linter tools (JSCS, JSHint, ESLint) support the option to limit the number of warnings ([--max-errors in jscs](http://jscs.info/overview#options), [maxerr in jshint](http://jshint.com/docs/options/#maxerr),  [--max-warnings in eslint](http://eslint.org/docs/user-guide/command-line-interface.html)). I added the similar options to pronto.
                                                                                                                                                 
P.S. I use pronto everyday! I really appreciate you!