### PR TITLE
Colorize text formatter

### DIFF
--- a/lib/pronto.rb
+++ b/lib/pronto.rb
@@ -3,6 +3,7 @@ require 'octokit'
 require 'gitlab'
 require 'forwardable'
 require 'httparty'
+require 'rainbow'
 
 require 'pronto/gem_names'
 
@@ -25,6 +26,7 @@ require 'pronto/github'
 require 'pronto/gitlab'
 require 'pronto/bitbucket'
 
+require 'pronto/formatter/colorizable'
 require 'pronto/formatter/text_formatter'
 require 'pronto/formatter/json_formatter'
 require 'pronto/formatter/github_formatter'

--- a/lib/pronto/formatter/colorizable.rb
+++ b/lib/pronto/formatter/colorizable.rb
@@ -1,0 +1,17 @@
+module Pronto
+  module Formatter
+    module Colorizable
+      def colorize(string, color)
+        rainbow.wrap(string).color(color)
+      end
+
+      private
+
+      def rainbow
+        @rainbow ||= Rainbow.new.tap do |rainbow|
+          rainbow.enabled = $stdout.tty?
+        end
+      end
+    end
+  end
+end

--- a/lib/pronto/formatter/text_formatter.rb
+++ b/lib/pronto/formatter/text_formatter.rb
@@ -1,22 +1,44 @@
 module Pronto
   module Formatter
     class TextFormatter
+      include Colorizable
+
+      LOCATION_COLOR = :cyan
+
+      LEVEL_COLORS = {
+        info: :yellow,
+        warning: :magenta,
+        error: :red,
+        fatal: :red
+      }.freeze
+
       def format(messages, _, _)
         messages.map do |message|
-          level = message.level[0].upcase
-          "#{location(message)} #{level}: #{message.msg}"
+          "#{format_location(message)} #{format_level(message)}: #{message.msg}".strip
         end
       end
 
       private
 
-      def location(message)
+      def format_location(message)
         line = message.line
         lineno = line.new_lineno if line
         path = message.path
-        commit_sha = message.commit_sha[0..6] if message.commit_sha
+        commit_sha = message.commit_sha
 
-        (path.nil? && lineno.nil?) ? commit_sha : "#{path}:#{lineno}"
+        if path || lineno
+          path = colorize(path, LOCATION_COLOR) if path
+          "#{path}:#{lineno}"
+        elsif commit_sha
+          colorize(commit_sha[0..6], LOCATION_COLOR)
+        end
+      end
+
+      def format_level(message)
+        level = message.level
+        color = LEVEL_COLORS.fetch(level)
+
+        colorize(level[0].upcase, color)
       end
     end
   end

--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('octokit', '~> 4.3', '>= 4.1.0')
   s.add_runtime_dependency('gitlab', '~> 3.6', '>= 3.4.0')
   s.add_runtime_dependency('httparty', '~> 0.13.7')
+  s.add_runtime_dependency('rainbow', '~> 2.1')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')

--- a/spec/pronto/formatter/colorizable_spec.rb
+++ b/spec/pronto/formatter/colorizable_spec.rb
@@ -1,0 +1,37 @@
+module Pronto
+  module Formatter
+    describe Colorizable do
+      let(:formatter_class) do
+        klass = described_class
+
+        Class.new(TextFormatter) do
+          include klass
+        end
+      end
+
+      let(:formatter) do
+        formatter_class.new
+      end
+
+      describe '#colorize' do
+        subject { formatter.colorize('Warning', :yellow) }
+
+        context 'in TTY' do
+          before { $stdout.stub(:tty?) { true } }
+
+          it 'colorizes the passed string' do
+            should eq("\e[33mWarning\e[0m")
+          end
+        end
+
+        context 'not in TTY' do
+          before { $stdout.stub(:tty?) { false } }
+
+          it 'returns the passed string' do
+            should eq('Warning')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pronto/formatter/text_formatter_spec.rb
+++ b/spec/pronto/formatter/text_formatter_spec.rb
@@ -3,6 +3,8 @@ module Pronto
     describe TextFormatter do
       let(:formatter) { described_class.new }
 
+      before { $stdout.stub(:tty?) { false } }
+
       describe '#format' do
         subject { formatter.format(messages, nil, nil) }
         let(:messages) { [message, message] }
@@ -11,6 +13,13 @@ module Pronto
 
         its(:count) { should == 2 }
         its(:first) { should == 'path/to:1 W: crucial' }
+
+        context 'message with commit SHA' do
+          let(:message) { Message.new(nil, nil, :warning, 'careful', '8d79b5') }
+
+          its(:count) { should == 2 }
+          its(:first) { should == '8d79b5 W: careful' }
+        end
 
         context 'message without path' do
           let(:message) { Message.new(nil, line, :warning, 'careful') }
@@ -24,6 +33,66 @@ module Pronto
 
           its(:count) { should == 2 }
           its(:first) { should == 'path/to: W: careful' }
+        end
+
+        context 'message without line, path and commit SHA' do
+          let(:message) { Message.new(nil, nil, :warning, 'careful', nil) }
+
+          its(:count) { should == 2 }
+          its(:first) { should == 'W: careful' }
+        end
+
+        context 'in TTY' do
+          before { $stdout.stub(:tty?) { true } }
+
+          context 'message with commit SHA' do
+            let(:message) { Message.new(nil, nil, :warning, 'msg', '8d79b5') }
+
+            its(:first) { should == "\e[36m8d79b5\e[0m \e[35mW\e[0m: msg" }
+          end
+
+          context 'message without path' do
+            let(:message) { Message.new(nil, line, :warning, 'msg') }
+
+            its(:first) { should == ":1 \e[35mW\e[0m: msg" }
+          end
+
+          context 'message without line' do
+            let(:message) { Message.new('path/to', nil, :warning, 'msg') }
+
+            its(:first) { should == "\e[36mpath/to\e[0m: \e[35mW\e[0m: msg" }
+          end
+
+          context 'message without line, path and commit SHA' do
+            let(:message) { Message.new(nil, nil, :warning, 'careful', nil) }
+
+            its(:count) { should == 2 }
+            its(:first) { should == "\e[35mW\e[0m: careful" }
+          end
+
+          context 'info message' do
+            let(:message) { Message.new('path/to', line, :info, 'msg') }
+
+            its(:first) { should == "\e[36mpath/to\e[0m:1 \e[33mI\e[0m: msg" }
+          end
+
+          context 'warning message' do
+            let(:message) { Message.new('path/to', line, :warning, 'msg') }
+
+            its(:first) { should == "\e[36mpath/to\e[0m:1 \e[35mW\e[0m: msg" }
+          end
+
+          context 'error message' do
+            let(:message) { Message.new('path/to', line, :error, 'msg') }
+
+            its(:first) { should == "\e[36mpath/to\e[0m:1 \e[31mE\e[0m: msg" }
+          end
+
+          context 'fatal message' do
+            let(:message) { Message.new('path/to', line, :fatal, 'msg') }
+
+            its(:first) { should == "\e[36mpath/to\e[0m:1 \e[31mF\e[0m: msg" }
+          end
         end
       end
     end


### PR DESCRIPTION
This PR colorizes the text formatter to improve terminal readability when used locally.

Before
<img width="627" alt="before" src="https://cloud.githubusercontent.com/assets/705812/13967902/386abb42-f082-11e5-8385-97c942c66c38.png">

After
<img width="625" alt="after" src="https://cloud.githubusercontent.com/assets/705812/13967904/3c620480-f082-11e5-9c74-5b7513786508.png">

### Configuration

The new feature is controlled via `text_formatter`:`colors` property in `.pronto.yml`. This is also reflected in the `README.md`. By default it's disabled.

This feature is always disabled (configuration is ignored) when not in TTY to enable file I/O redirection, `grep`, etc.

N.B. I've had some hard time trying to enable it by default as there seems to be some issues with overriding truthy `ConfigFile::EMPTY` values via `.pronto.yml`/`ENV` settings. I'll investigate further and report back.

P.S. I've left the proposed `--colored` option out as it would require a bit of a bigger refactoring to centralize the configuration and its modification. Currently `TEXT_FORMATTER_COLORS=true pronto run` will be available as an alternative.

### New dependencies

I've used Rainbow as suggested in #129.

### Colorizable mixin

This is a reusable module intended to be used by any formatter that may need colorization. Its implementation is inspired by the one seen in Rubocop.

### Colors and styles

The colors I've used are inspired by Rubocop as I find them to be quite nice and recognizable.

Resolves #129
