### PR TITLE
Run Pronto with Travis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 1.9
+
 Documentation:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,9 @@ rvm:
 - 2.1
 - 2.2
 - 2.3.0
+
+after_success:
+- >
+  [ "${TRAVIS_PULL_REQUEST}" = "false" ] || [ "${TRAVIS_RUBY_VERSION}" = "1.9.3" ] &&
+    PULL_REQUEST_ID=${TRAVIS_PULL_REQUEST} \
+      bundle exec pronto run -f github_status github_pr -c origin/${TRAVIS_BRANCH}

--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -52,4 +52,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec-expectations', '~> 3.4')
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('simplecov', '~> 0.11')
+  s.add_development_dependency('rubocop', '~> 0.39.0')
+  s.add_development_dependency('pronto-rubocop', '~> 0.6.2')
 end


### PR DESCRIPTION
I've noticed that there is a `.rubocop.yml` file in the repository. However neither rake nor CI is configured to run it.
I'm proposing to run pronto for pronto project itself to give good example to others :-)

@mmozuras What do you think?
If you're willing to give it a try:
* [generate token](https://github.com/settings/tokens/new) with `public_repo` scope
* add `GITHUB_ACCESS_TOKEN` env variable to [Travis configuration](https://travis-ci.org/mmozuras/pronto/settings)
