### PR TITLE
Add runner name to the text formatter

### DIFF
--- a/lib/pronto/formatter/text_formatter.rb
+++ b/lib/pronto/formatter/text_formatter.rb
@@ -14,7 +14,9 @@ module Pronto
 
       def format(messages, _, _)
         messages.map do |message|
-          "#{format_location(message)} #{format_level(message)}: #{message.msg}".strip
+          "#{format_location(message)} "\
+          "#{format_runner(message)}#{format_level(message)}: "\
+          "#{message.msg}".strip
         end
       end
 
@@ -39,6 +41,13 @@ module Pronto
         color = LEVEL_COLORS.fetch(level)
 
         colorize(level[0].upcase, color)
+      end
+
+      def format_runner(message)
+        runner = message.runner
+        return unless runner
+
+        runner.to_s.sub('Pronto::', '') + '/'
       end
     end
   end

--- a/spec/pronto/formatter/text_formatter_spec.rb
+++ b/spec/pronto/formatter/text_formatter_spec.rb
@@ -10,6 +10,7 @@ module Pronto
         let(:messages) { [message, message] }
         let(:message) { Message.new('path/to', line, :warning, 'crucial') }
         let(:line) { double(new_lineno: 1, commit_sha: '123') }
+        let(:runner) { double(to_s: 'Pronto::RunnerName') }
 
         its(:count) { should == 2 }
         its(:first) { should == 'path/to:1 W: crucial' }
@@ -42,6 +43,11 @@ module Pronto
           its(:first) { should == 'W: careful' }
         end
 
+        context 'message with runner' do
+          let(:message) { Message.new(nil, nil, :warning, 'careful', nil, runner) }
+          its(:first) { should == 'RunnerName/W: careful' }
+        end
+
         context 'in TTY' do
           before { $stdout.stub(:tty?) { true } }
 
@@ -68,6 +74,11 @@ module Pronto
 
             its(:count) { should == 2 }
             its(:first) { should == "\e[35mW\e[0m: careful" }
+          end
+
+          context 'message with runner' do
+            let(:message) { Message.new(nil, nil, :warning, 'careful', nil, runner) }
+            its(:first) { should == "RunnerName/\e[35mW\e[0m: careful" }
           end
 
           context 'info message' do


### PR DESCRIPTION
This PR adds runner name to the text formatter output.

![0](https://cloud.githubusercontent.com/assets/705812/14752029/a469cea8-08d5-11e6-86e0-e2a0a44a1e47.png)
### Motivation

When I'm reviewing my work using pronto with multiple runners enabled I often find myself fixing issues grouped not (only) by filename but by some kind of category - style, security, complexity, duplication, etc. I need a way to analyze, filter and order the output to suit my needs (using `grep`, `sort`, etc.). As the runner is currently not shown there is a gap in the message's context - I know the location, severity, etc. but not the reporter. Working around this currently involve starting `pronto` with the `--runner` option.
### Use case scenario

I want to run pronto on my branch once and fix `rubocop` issues first, then `reek` ones and completely ignore `jshint` at this stage. Additionally counting the messages from each runner would be nice. Also often there is a message that I don't agree with (and want to disable) or I don't understand (and need to check the docs) and I have no idea which runner reported it. 
