### PR TITLE
Fix Popper Issue mmozuras/pronto-poper#5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#134](https://github.com/mmozuras/pronto/pull/134): colorize text formatter.
 * [#144](https://github.com/mmozuras/pronto/pull/144): add GitHub status formatter.
 
+### Bugs fixed
+
+* [#153](https://github.com/mmozuras/pronto/pull/153): correctly get repo_path.
+
 ## 0.6.0
 
 ### New features

--- a/lib/pronto/runner.rb
+++ b/lib/pronto/runner.rb
@@ -23,7 +23,7 @@ module Pronto
     end
 
     def repo_path
-      ruby_patches.first.repo.path
+      @patches.first.repo.path
     end
 
     private


### PR DESCRIPTION
ruby_patches method sometimes returns an empty Array.
Calling #first on it will return nil that can cause errors.
So, using the bare @patches instance variable.

Fixes mmozuras/pronto-poper#5