### PR TITLE
Discover repository directory inside subdirectories

### DIFF
--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -49,7 +49,10 @@ module Pronto
 
       formatters = ::Pronto::Formatter.get(options[:formatters])
       commit = options[:index] ? :index : options[:commit]
-      messages = ::Pronto.run(commit, '.', formatters, path)
+      repo_workdir = ::Rugged::Repository.discover('.').workdir
+      messages = Dir.chdir(repo_workdir) do
+        ::Pronto.run(commit, '.', formatters, path)
+      end
       exit(messages.count) if options[:'exit-code']
     rescue Rugged::RepositoryError
       puts '"pronto" should be run from a git repository'


### PR DESCRIPTION
Uses Rugged::Repository#discover to discover the location of the git
repository if the current working directory is a subdirectory of the git
repository. Working directory is changed to the root of the repository
so that runners pick up the appropriate configuration files.

This allows running pronto within subdirectories of a git repository.