### PR TITLE
don't use an error exit code if all the messages are info.

### DIFF
--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -53,7 +53,10 @@ module Pronto
       messages = Dir.chdir(repo_workdir) do
         ::Pronto.run(commit, '.', formatters, path)
       end
-      exit(1) if options[:'exit-code'] && messages.any? { |m| m.level != :info }
+      if options[:'exit-code']
+        error_messages_count = messages.count { |m| m.level != :info }
+        exit(error_messages_count)
+      end
     rescue Rugged::RepositoryError
       puts '"pronto" should be run from a git repository'
     end

--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -53,7 +53,7 @@ module Pronto
       messages = Dir.chdir(repo_workdir) do
         ::Pronto.run(commit, '.', formatters, path)
       end
-      exit(messages.count) if options[:'exit-code']
+      exit(1) if options[:'exit-code'] && messages.any? { |m| m.level != :info }
     rescue Rugged::RepositoryError
       puts '"pronto" should be run from a git repository'
     end


### PR DESCRIPTION
Hi, 

I'm having this issue with exit code on info messages.

The doc implies that using the `--exit-code` flag, will only fail for errors and warnings.
```
--exit-code	Exits with non-zero code if there were any warnings/errors.
```

It was also returning non-zero exit code if all the messages are `info` level messages (in my case, pronto-rubocop 'refactor' severity)

Thanks for your time. 

Dan.