### PR TITLE
Prevent crashing when files were removed

### DIFF
--- a/lib/pronto/runner.rb
+++ b/lib/pronto/runner.rb
@@ -40,7 +40,7 @@ module Pronto
       return false if File.directory?(path)
       line = File.open(path, &:readline)
       line =~ /#!.*ruby/
-    rescue ArgumentError, EOFError
+    rescue ArgumentError, EOFError, Errno::ENOENT
       false
     end
   end


### PR DESCRIPTION
When a file was removed in the changeset, pronto would try to open it, leading to errors like

    Errno::ENOENT: No such file or directory @ rb_sysopen - ...

This patch makes sure that the method returns `false` as expected.