### PR TITLE
Prefix Pronto ENV config variables

### DIFF
--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -7,12 +7,12 @@ module Pronto
     %w(github gitlab bitbucket).each do |service|
       ConfigFile::EMPTY[service].each do |key, _|
         name = "#{service}_#{key}"
-        define_method(name) { ENV[name.upcase] || @config_hash[service][key] }
+        define_method(name) { ENV["PRONTO_#{name.upcase}"] || @config_hash[service][key] }
       end
     end
 
     def consolidate_comments?
-      consolidated = ENV['CONSOLIDATE_COMMENTS'] || @config_hash['consolidate_comments']
+      consolidated = ENV['PRONTO_CONSOLIDATE_COMMENTS'] || @config_hash['consolidate_comments']
       !(consolidated).nil?
     end
 
@@ -31,12 +31,12 @@ module Pronto
     end
 
     def max_warnings
-      ENV['MAX_WARNINGS'] || @config_hash['max_warnings']
+      ENV['PRONTO_MAX_WARNINGS'] || @config_hash['max_warnings']
     end
 
     def logger
       @logger ||= begin
-        verbose = ENV['VERBOSE'] || @config_hash['verbose']
+        verbose = ENV['PRONTO_VERBOSE'] || @config_hash['verbose']
         verbose ? Logger.new($stdout) : Logger.silent
       end
     end
@@ -44,7 +44,7 @@ module Pronto
     private
 
     def exclude
-      ENV['EXCLUDE'] || @config_hash['all']['exclude']
+      ENV['PRONTO_EXCLUDE'] || @config_hash['all']['exclude']
     end
   end
 end

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -7,7 +7,7 @@ module Pronto
       subject { config.github_slug }
 
       context 'from env variable' do
-        before { stub_const('ENV', 'GITHUB_SLUG' => 'mmozuras/pronto') }
+        before { stub_const('ENV', 'PRONTO_GITHUB_SLUG' => 'mmozuras/pronto') }
         it { should == 'mmozuras/pronto' }
       end
 
@@ -21,7 +21,7 @@ module Pronto
       subject { config.github_web_endpoint }
 
       context 'from env variable' do
-        before { stub_const('ENV', 'GITHUB_WEB_ENDPOINT' => '4.2.2.2') }
+        before { stub_const('ENV', 'PRONTO_GITHUB_WEB_ENDPOINT' => '4.2.2.2') }
         it { should == '4.2.2.2' }
       end
 
@@ -46,7 +46,7 @@ module Pronto
       subject { config.gitlab_slug }
 
       context 'from env variable' do
-        before { stub_const('ENV', 'GITLAB_SLUG' => 'rick/deckard') }
+        before { stub_const('ENV', 'PRONTO_GITLAB_SLUG' => 'rick/deckard') }
         it { should == 'rick/deckard' }
       end
 

--- a/spec/pronto/formatter/gitlab_formatter_spec.rb
+++ b/spec/pronto/formatter/gitlab_formatter_spec.rb
@@ -1,8 +1,8 @@
 module Pronto
   module Formatter
     describe GitlabFormatter do
-      ENV['GITLAB_API_ENDPOINT'] = 'http://example.com/api/v3'
-      ENV['GITLAB_API_PRIVATE_TOKEN'] = 'token'
+      ENV['PRONTO_GITLAB_API_ENDPOINT'] = 'http://example.com/api/v3'
+      ENV['PRONTO_GITLAB_API_PRIVATE_TOKEN'] = 'token'
 
       let(:formatter) { described_class.new }
 

--- a/spec/pronto/gitlab_spec.rb
+++ b/spec/pronto/gitlab_spec.rb
@@ -5,8 +5,8 @@ module Pronto
     describe '#slug' do
       subject { gitlab.send(:slug) }
       before(:each) do
-        ENV['GITLAB_API_ENDPOINT'] = 'http://gitlab.example.com/api/v3'
-        ENV['GITLAB_API_PRIVATE_TOKEN'] = 'token'
+        ENV['PRONTO_GITLAB_API_ENDPOINT'] = 'http://gitlab.example.com/api/v3'
+        ENV['PRONTO_GITLAB_API_PRIVATE_TOKEN'] = 'token'
       end
 
       context 'ssh with port remote url' do
@@ -42,8 +42,8 @@ module Pronto
         let(:comment) { double(note: 'body', path: 'path', line: 1) }
 
         specify do
-          ENV['GITLAB_API_ENDPOINT'] = 'http://gitlab.example.com/api/v3'
-          ENV['GITLAB_API_PRIVATE_TOKEN'] = 'token'
+          ENV['PRONTO_GITLAB_API_ENDPOINT'] = 'http://gitlab.example.com/api/v3'
+          ENV['PRONTO_GITLAB_API_PRIVATE_TOKEN'] = 'token'
 
           ::Gitlab::Client.any_instance
             .should_receive(:commit_comments)


### PR DESCRIPTION
@mmozuras this PR prefixes all of the Pronto configuration variable ENVs.  Let me know your thoughts.

Examples:
- `CONSOLIDATE_COMMENTS` -> `PRONTO_CONSOLIDATE_COMMENTS`
- `GITHUB_SLUG` -> `PRONTO_GITHUB_SLUG`
- `MAX_WARNINGS ` -> `PRONTO_MAX_WARNINGS `
- `VERBOSE` -> `PRONTO_VERBOSE `