### PR TITLE
Allow for nil and false values for consolidation

### DIFF
--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -12,8 +12,10 @@ module Pronto
     end
 
     def consolidate_comments?
-      consolidated = ENV['PRONTO_CONSOLIDATE_COMMENTS'] || @config_hash['consolidate_comments']
-      !(consolidated).nil?
+      consolidated =
+        ENV['PRONTO_CONSOLIDATE_COMMENTS'] ||
+        @config_hash.fetch('consolidate_comments', false)
+      consolidated
     end
 
     def excluded_files


### PR DESCRIPTION
As @mknapik pointed out [here](https://github.com/mmozuras/pronto/pull/154#r83859578) the existing config changes I made were not sufficiently checking for `nil` _and_ `false`, this PR changes that.

Thoughts @mmozuras?