### PR TITLE
Fix nil consolidated comment

### DIFF
--- a/lib/pronto/formatter/git_formatter.rb
+++ b/lib/pronto/formatter/git_formatter.rb
@@ -83,7 +83,7 @@ module Pronto
           existing = old_comments[key]
           comments = dedupe_comments(existing, comments) if existing
 
-          if config.consolidate_comments?
+          if config.consolidate_comments? && !comments.empty?
             comment = consolidate_comments(comments)
             memo.push(comment)
           else


### PR DESCRIPTION
If all comments already existed,
consolidation feature transformed empty list into nil.

Fixes #188 