### PR TITLE
Allow HTTParty 0.14

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('thor', '~> 0.19.0')
   s.add_runtime_dependency('octokit', '~> 4.3', '>= 4.1.0')
   s.add_runtime_dependency('gitlab', '~> 3.6', '>= 3.4.0')
-  s.add_runtime_dependency('httparty', '~> 0.13.7')
+  s.add_runtime_dependency('httparty', '>= 0.13.7', '< 0.15')
   s.add_runtime_dependency('rainbow', '~> 2.1')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')


### PR DESCRIPTION
HTTParty 0.14 removes dependency to JSON gem and is thus compatible with Ruby 2.4.

Gitlab 3.7 locks to HTTParty 0.13, but the next version will drop that requirement. Using Gitlab 3.6 should also work.