### PR TITLE
Stop warning message on default formatter

### DIFF
--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -37,7 +37,7 @@ module Pronto
 
     method_option :formatters,
                   type: :array,
-                  default: 'text',
+                  default: ['text'],
                   aliases: ['formatter', '-f'],
                   desc: "Pick output formatters. Available: #{::Pronto::Formatter.names.join(', ')}"
 


### PR DESCRIPTION
When I run `pronto` I get a warning:

```
$ pronto run
Expected array default value for '--formatters'; got "text" (string)
```

This fixes it. Everything else seems to be working fine.