### PR TITLE
Change example configuration for gitlab/slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ github:
   api_endpoint: https://api.github.com/
   web_endpoint: https://github.com/
 gitlab:
-  slug: mmozuras/42
+  slug: 1234567 # gitlab's project ID
   api_private_token: 46751
   api_endpoint: https://api.vinted.com/gitlab
 bitbucket:


### PR DESCRIPTION
The example slug for gitlab is incorrect. The gitlab API looks up projects by its project id alone - the
username is never used.

It looks like there's been several issues reported about this already, so thought I'd make the docs a bit more clear.

I've enjoyed using pronto, thanks!