### PR TITLE
Preventing NoMethodError at `Pronto::Runners#run` with exclude config

### DIFF
--- a/lib/pronto/runners.rb
+++ b/lib/pronto/runners.rb
@@ -28,9 +28,10 @@ module Pronto
     def reject_excluded(excluded_files, patches)
       return patches unless excluded_files.any?
 
-      patches.reject do |patch|
+      patches.reject! do |patch|
         excluded_files.include?(patch.new_file_full_path.to_s)
       end
+      patches
     end
 
     def exceeds_max?(warnings)


### PR DESCRIPTION
This PR prevents `NoMethodError` while running `pronto run` with exclude config.

## How to reproduce


Setup:
```console
[~/src]$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]

[~/src]$ mkdir test && cd test

[~/src/test]$ vi Gemfile
[~/src/test]$ cat Gemfile
source 'https://rubygems.org'
gem 'rake'
gem 'pronto', '0.8.1'
gem 'pronto-rubocop', '0.8.0'

[~/src/test]$ bundle install --path .bundle
```

Initialize repo, create branch and add commit:
```console
[~/src/test]$ git init
[~/src/test]$ git add Gemfile*
[~/src/test]$ git commit -m 'first commit'

[~/src/test]$ git checkout -b feature 

[~/src/test]$ echo "puts 'Foo'" > foo.rb
[~/src/test]$ mkdir spec
[~/src/test]$ echo "puts 'Bar'" > spec/bar.rb
[~/src/test]$ git add foo.rb spec/bar.rb
[~/src/test]$ git commit -m 'add foo.rb and spec/bar.rb'
```

Run with exclude config (NG):

```console
$ vi .pronto.yml
$ cat .pronto.yml
all:
  exclude:
    - 'spec/**/*'

$ bundle exec pronto run
bundler: failed to load command: pronto (/Users/juno/src/test/.bundle/ruby/2.4.0/bin/pronto)
NoMethodError: undefined method `commit' for #<Array:0x007f93977c7798>
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto/runners.rb:20:in `block in run'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto/runners.rb:13:in `each'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto/runners.rb:13:in `run'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto.rb:56:in `run'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto/cli.rb:54:in `block in run'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto/cli.rb:53:in `chdir'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/lib/pronto/cli.rb:53:in `run'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
  /Users/juno/src/test/.bundle/ruby/2.4.0/gems/pronto-0.8.1/bin/pronto:6:in `<top (required)>'
  /Users/juno/src/test/.bundle/ruby/2.4.0/bin/pronto:22:in `load'
  /Users/juno/src/test/.bundle/ruby/2.4.0/bin/pronto:22:in `<top (required)>'
```

Run without exclude config (OK):

```console
[~/src/test]$ rm .pronto.yml
[~/src/test]$ bundle exec pronto run
```

## Root cause

PR #185 introduced unintentionally return type conversion at [Pronto::Runner#reject_excluded](https://github.com/astrauka/pronto/blob/94d42ce76643cd43c986fe35ff9951ef0f79e8a1/lib/pronto/runners.rb#L28-L34).

```diff
-    def reject_excluded(patches)
-      return patches unless @config.excluded_files.any?
-      patches.reject! { |patch| excluded?(patch) }
-      patches
-    end
+    def reject_excluded(excluded_files, patches)
+      return patches unless excluded_files.any?
  
-    def excluded?(patch)
-      @config.excluded_files.include?(patch.new_file_full_path.to_s)
+      patches.reject do |patch|
+        excluded_files.include?(patch.new_file_full_path.to_s)
+      end
     end
```

Since `Pronto::Git::Patches` does override `reject!` but `reject` doesn't, therefore `Enumerable#reject` has called and the method returns `Array` instead `Pronto::Git::Patches`.


