### PR TITLE
Do not mutate patches when excluding single runner files

### DIFF
--- a/lib/pronto/git/patches.rb
+++ b/lib/pronto/git/patches.rb
@@ -15,8 +15,8 @@ module Pronto
         @patches.each(&block)
       end
 
-      def reject!(&block)
-        @patches.reject!(&block)
+      def reject(&block)
+        Pronto::Git::Patches.new(repo, commit, @patches.reject(&block))
       end
 
       def find_line(path, line)

--- a/lib/pronto/runners.rb
+++ b/lib/pronto/runners.rb
@@ -28,10 +28,9 @@ module Pronto
     def reject_excluded(excluded_files, patches)
       return patches unless excluded_files.any?
 
-      patches.reject! do |patch|
+      patches.reject do |patch|
         excluded_files.include?(patch.new_file_full_path.to_s)
       end
-      patches
     end
 
     def exceeds_max?(warnings)

--- a/spec/pronto/git/patches_spec.rb
+++ b/spec/pronto/git/patches_spec.rb
@@ -1,9 +1,10 @@
 module Pronto
   module Git
     describe Patches do
-      let(:patches) { described_class.new(repo, commit, []) }
+      let(:patches) { described_class.new(repo, commit, patch_array) }
       let(:repo) { nil }
       let(:commit) { nil }
+      let(:patch_array) { [] }
 
       describe '#repo' do
         subject { patches.repo }
@@ -14,9 +15,14 @@ module Pronto
         end
       end
 
-      describe '#reject!' do
-        subject { patches.reject! { |_| true } }
-        its(:to_a) { should be_empty }
+      describe '#reject' do
+        subject { patches.reject { |_| true } }
+        let(:patch_array) { [double(new_file_full_path: 1)] }
+
+        it 'does not modify original' do
+          subject.to_a.should be_empty
+          patches.to_a.should_not be_empty
+        end
       end
 
       describe '#find_line' do


### PR DESCRIPTION
Do not mutate patches when excluding single runner files

With mutation single runner excluded patches are removed from `@patches`
and not run for following runners.

@mmozuras @juno returning a new object instead of mutating existing one.